### PR TITLE
Firesotreとの結合部分に関して処理を切り出す

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { EnvironmentsModule } from './config/enviroments.module';
 import { PrideUserModule } from './pride-user/pride-user.module';
 import { PrideModule } from './pride/pride.module';
+import { StorePrideModule } from './store/store-pride/store-pride.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { PrideModule } from './pride/pride.module';
     DevtoolsModule.register({
       http: process.env.NODE_ENV !== 'prod',
     }),
+    StorePrideModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/pride-user/pride-user.module.ts
+++ b/backend/src/pride-user/pride-user.module.ts
@@ -4,6 +4,6 @@ import { PrideUserService } from './pride-user.service';
 
 @Module({
   controllers: [PrideUserController],
-  providers: [PrideUserService]
+  providers: [PrideUserService],
 })
 export class PrideUserModule {}

--- a/backend/src/pride-user/pride-user.service.ts
+++ b/backend/src/pride-user/pride-user.service.ts
@@ -1,88 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { DocumentData, FirestoreDataConverter, QueryDocumentSnapshot, Timestamp } from 'firebase-admin/firestore';
-import { EnvironmentsService } from 'src/config/enviroments.service';
-import { PrideContent } from 'src/types/prideContent';
+import { StorePrideService } from 'src/store/store-pride/store-pride.service';
 import { RequestPrideContentDto, RequestUserIDDto } from './dto/request.dto';
 
 @Injectable()
 export class PrideUserService {
-  constructor(private readonly env: EnvironmentsService) {}
-  prideDB = this.env.firestoreDB.collection('prides');
-  userConverter: FirestoreDataConverter<PrideContent> = {
-    fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData>) {
-      const timestamp = snapshot.get('createdAt') as Timestamp;
-      const createdAt = new Date(timestamp.seconds * 1000);
+  constructor(private readonly prideStore: StorePrideService) {}
 
-      return {
-        uid: snapshot.id,
-        title: snapshot.get('title') || '',
-        memo: snapshot.get('memo') || '',
-        thumbsupCount: snapshot.get('thumbsupCount'),
-        thumbsupUsers: snapshot.get('thumbsupUsers') || [],
-        createdAt: createdAt,
-        userID: snapshot.get('userID') || '',
-        userName: snapshot.get('userName') || '',
-        userPhotoURL: snapshot.get('userPhotoURL') || '',
-      };
-    },
-    toFirestore(data: PrideContent): DocumentData {
-      return {
-        title: data.title,
-        memo: data.memo,
-        thumbsupCount: data.thumbsupCount,
-        thumbsupUsers: data.thumbsupUsers,
-        createdAt: data.createdAt ? data.createdAt : new Date(),
-        userID: data.userID,
-        userName: data.userName,
-        userPhotoURL: data.userPhotoURL,
-      };
-    },
-  };
-  async isExistPride(uid: string) {
-    const prideRef = await this.prideDB.doc(uid).withConverter(this.userConverter).get();
-    return prideRef.exists;
-  }
-  async getMyPride(uid: string) {
-    const prideRef = await this.prideDB.doc(uid).withConverter(this.userConverter).get();
-    const pride = prideRef.data();
-    return pride;
-  }
   async getMyPrideWithinOnePride(request: RequestUserIDDto) {
-    const today = new Date();
-    const oneMonthAgo =
-      today.getMonth() - 1 >= 0
-        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-        : new Date(today.getFullYear() - 1, 11, today.getDate());
-    // TODO:ここが年をまたぐ場合エラー回避
-    const prideCollection = await this.prideDB
-      .withConverter(this.userConverter)
-      .where('userID', '==', request.userID)
-      .where('createdAt', '>=', oneMonthAgo)
-      .orderBy('createdAt', 'desc')
-      .get();
-    const prides = prideCollection.docs.map((doc) => doc.data());
-    //過去一か月のPrideを取得
+    const prides = await this.prideStore.getUsersPrideWithInOneMonth(request.userID);
     return prides;
   }
   async createPride(request: RequestPrideContentDto): Promise<void> {
-    this.prideDB.withConverter(this.userConverter).add({
-      uid: '',
-      title: request.title,
-      memo: request.memo,
-      thumbsupUsers: [],
-      thumbsupCount: 0,
-      userID: request.userID,
-      userName: request.userName,
-      userPhotoURL: request.userPhoto,
-    });
+    await this.prideStore.createPride(request.userID, request.userName, request.userPhoto, request.title, request.memo);
   }
-  async updatePride(uid: string, request: RequestPrideContentDto): Promise<void> {
-    this.prideDB.doc(uid).withConverter(this.userConverter).update({
-      title: request.title,
-      memo: request.memo,
-    });
+  async updatePride(prideID: string, request: RequestPrideContentDto): Promise<void> {
+    await this.prideStore.updatePride(prideID, request.title, request.memo);
   }
-  async deletePride(uid: string): Promise<void> {
-    this.prideDB.doc(uid).delete();
+  async deletePride(prideID: string): Promise<void> {
+    await this.prideStore.deletePride(prideID);
+  }
+  async isExistPride(prideID: string): Promise<boolean> {
+    return await this.prideStore.isExistPride(prideID);
   }
 }

--- a/backend/src/pride/pride.service.ts
+++ b/backend/src/pride/pride.service.ts
@@ -1,109 +1,34 @@
 import { Injectable } from '@nestjs/common';
-import { DocumentData, FirestoreDataConverter, QueryDocumentSnapshot, Timestamp } from 'firebase-admin/firestore';
-import { EnvironmentsService } from 'src/config/enviroments.service';
-import { PrideContent } from 'src/types/prideContent';
+import { StorePrideService } from 'src/store/store-pride/store-pride.service';
 import { RequestThumbsUpPrideDto } from './dto/request.dto';
 
 @Injectable()
 export class PrideService {
-  constructor(private readonly env: EnvironmentsService) {}
-  prideDB = this.env.firestoreDB.collection('prides');
+  constructor(private readonly prideStore: StorePrideService) {}
 
-  prideConverter: FirestoreDataConverter<PrideContent> = {
-    fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData>) {
-      const timestamp = snapshot.get('createdAt') as Timestamp;
-      const createdAt = new Date(timestamp.seconds * 1000);
-
-      const thumbsupUsers = (snapshot.get('thumbsupUsers') || []) as string[];
-
-      return {
-        uid: snapshot.id,
-        title: snapshot.get('title') || '',
-        memo: snapshot.get('memo') || '',
-        thumbsupUsers: thumbsupUsers,
-        thumbsupCount: snapshot.get('thumbsupCount'),
-        createdAt: createdAt,
-        userName: snapshot.get('userName') || '',
-        userID: snapshot.get('userID') || '',
-        userPhotoURL: snapshot.get('userPhotoURL') || '',
-      };
-    },
-    toFirestore() {
-      return {};
-    },
-  };
   async getPridesWithinOneMonth() {
-    const today = new Date();
-    const oneMonthAgo =
-      today.getMonth() - 1 >= 0
-        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-        : new Date(today.getFullYear() - 1, 11, today.getDate());
-
-    // TODO:年をまたぐ場合にエラー回避
-    const prideCollection = await this.prideDB
-      .where('createdAt', '>=', oneMonthAgo)
-      .orderBy('createdAt', 'desc')
-      .withConverter(this.prideConverter)
-      .get();
-    const prides = prideCollection.docs.map((doc) => doc.data());
+    const prides = await this.prideStore.getPridesWithinOneMonth();
     return prides;
   }
   async getPrideWithinOneMonthRanking() {
-    const today = new Date();
-
-    const oneMonthAgo =
-      today.getMonth() - 1 >= 0
-        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-        : new Date(today.getFullYear() - 1, 11, today.getDate());
-    // TODO:年をまたぐ場合にエラー回避
-    const prideCollection = await this.prideDB
-      .withConverter(this.prideConverter)
-      .where('createdAt', '>', oneMonthAgo)
-      .orderBy('createdAt', 'asc')
-      .orderBy('thumbsupCount', 'desc')
-      .limit(3)
-      .get();
-
-    const prides = prideCollection.docs.map((doc) => doc.data());
-
+    const prides = await this.prideStore.getPrideWithinOneMonthRanking();
     return prides;
   }
   async getPridePast() {
-    const today = new Date();
-    const oneMonthAgo =
-      today.getMonth() - 1 >= 0
-        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-        : new Date(today.getFullYear() - 1, 11, today.getDate());
-    const halfYearAgo =
-      today.getMonth() - 6 > 0
-        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
-        : new Date(today.getFullYear() - 1, 11 + today.getMonth() - 6, today.getDate());
-    // TODO:年をまたぐ場合にエラー回避
-    const prideCollection = await this.prideDB
-      .where('createdAt', '>=', halfYearAgo)
-      .where('createdAt', '<', oneMonthAgo)
-      .orderBy('createdAt', 'asc')
-      .withConverter(this.prideConverter)
-      .get();
-    const prides = prideCollection.docs.map((doc) => doc.data());
+    const prides = await this.prideStore.getPridePast();
     return prides;
   }
-  async isExistPride(uid: string) {
-    const pride = await this.prideDB.doc(uid).get();
-    return pride.exists;
-  }
+  async patchThumbsupPride(prideID: string, request: RequestThumbsUpPrideDto) {
+    const pride = await this.prideStore.getPride(prideID);
 
-  async patchThumbsupPride(uid: string, request: RequestThumbsUpPrideDto) {
-    const pride = await this.prideDB.doc(uid).withConverter(this.prideConverter).get();
-    const data = pride.data();
-
-    const thumbsupUsers = data.thumbsupUsers;
+    const thumbsupUsers = pride.thumbsupUsers;
     const updateThumbsupUsers = thumbsupUsers.includes(request.userPhoto)
       ? thumbsupUsers.filter((user) => user !== request.userPhoto)
       : [...thumbsupUsers, request.userPhoto];
-    this.prideDB.doc(uid).update({
-      thumbsupUsers: updateThumbsupUsers,
-      thumbsupCount: updateThumbsupUsers.length,
-    });
+
+    await this.prideStore.ThumbUpPride(prideID, updateThumbsupUsers, updateThumbsupUsers.length);
+  }
+  async isExistPride(prideID: string) {
+    return await this.prideStore.isExistPride(prideID);
   }
 }

--- a/backend/src/pride/pride.service.ts
+++ b/backend/src/pride/pride.service.ts
@@ -26,7 +26,7 @@ export class PrideService {
       ? thumbsupUsers.filter((user) => user !== request.userPhoto)
       : [...thumbsupUsers, request.userPhoto];
 
-    await this.prideStore.ThumbUpPride(prideID, updateThumbsupUsers, updateThumbsupUsers.length);
+    await this.prideStore.updateThumbUpPride(prideID, updateThumbsupUsers, updateThumbsupUsers.length);
   }
   async isExistPride(prideID: string) {
     return await this.prideStore.isExistPride(prideID);

--- a/backend/src/store/store-pride/store-pride.module.ts
+++ b/backend/src/store/store-pride/store-pride.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { StorePrideService } from './store-pride.service';
 
+@Global()
 @Module({
   providers: [StorePrideService],
   exports: [StorePrideService],

--- a/backend/src/store/store-pride/store-pride.module.ts
+++ b/backend/src/store/store-pride/store-pride.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StorePrideService } from './store-pride.service';
+
+@Module({
+  providers: [StorePrideService],
+  exports: [StorePrideService],
+})
+export class StorePrideModule {}

--- a/backend/src/store/store-pride/store-pride.service.spec.ts
+++ b/backend/src/store/store-pride/store-pride.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StorePrideService } from './store-pride.service';
+
+describe('StorePrideService', () => {
+  let service: StorePrideService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StorePrideService],
+    }).compile();
+
+    service = module.get<StorePrideService>(StorePrideService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/store/store-pride/store-pride.service.ts
+++ b/backend/src/store/store-pride/store-pride.service.ts
@@ -146,15 +146,14 @@ export class StorePrideService {
       memo: memo,
     });
   }
-
-  async deletePride(prideID: string) {
-    this.prideDB.doc(prideID).delete();
-  }
-
-  async ThumbUpPride(prideID: string, thumbsupUsers: string[], thumbsupCount: number) {
+  async updateThumbUpPride(prideID: string, thumbsupUsers: string[], thumbsupCount: number) {
     this.prideDB.doc(prideID).update({
       thumbsupUsers: thumbsupUsers,
       thumbsupCount: thumbsupCount,
     });
+  }
+
+  async deletePride(prideID: string) {
+    this.prideDB.doc(prideID).delete();
   }
 }

--- a/backend/src/store/store-pride/store-pride.service.ts
+++ b/backend/src/store/store-pride/store-pride.service.ts
@@ -45,6 +45,10 @@ export class StorePrideService {
     const pride = await this.prideDB.doc(uid).get();
     return pride.exists;
   }
+  async getPride(prideID: string) {
+    const pride = await this.prideDB.doc(prideID).withConverter(this.prideConverter).get();
+    return pride.data();
+  }
 
   async getUsersPrideWithInOneMonth(uid: string) {
     const today = new Date();
@@ -147,18 +151,10 @@ export class StorePrideService {
     this.prideDB.doc(prideID).delete();
   }
 
-  async ThumbUpPride(prideID: string, userPhoto: string) {
-    // 受け取った情報をもとに、いいねを更新する
-    const pride = await this.prideDB.doc(prideID).withConverter(this.prideConverter).get();
-    const data = pride.data();
-
-    const thumbsupUsers = data.thumbsupUsers;
-    const updateThumbsupUsers = thumbsupUsers.includes(userPhoto)
-      ? thumbsupUsers.filter((user) => user !== userPhoto)
-      : [...thumbsupUsers, userPhoto];
+  async ThumbUpPride(prideID: string, thumbsupUsers: string[], thumbsupCount: number) {
     this.prideDB.doc(prideID).update({
-      thumbsupUsers: updateThumbsupUsers,
-      thumbsupCount: updateThumbsupUsers.length,
+      thumbsupUsers: thumbsupUsers,
+      thumbsupCount: thumbsupCount,
     });
   }
 }

--- a/backend/src/store/store-pride/store-pride.service.ts
+++ b/backend/src/store/store-pride/store-pride.service.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@nestjs/common';
+import { DocumentData, FirestoreDataConverter, QueryDocumentSnapshot, Timestamp } from 'firebase-admin/firestore';
+import { EnvironmentsService } from 'src/config/enviroments.service';
+import { PrideContent } from 'src/types/prideContent';
+
+@Injectable()
+export class StorePrideService {
+  constructor(private readonly env: EnvironmentsService) {}
+  prideDB = this.env.firestoreDB.collection('prides');
+
+  prideConverter: FirestoreDataConverter<PrideContent> = {
+    fromFirestore(snapshot: QueryDocumentSnapshot<DocumentData>) {
+      const timestamp = snapshot.get('createdAt') as Timestamp;
+      const createdAt = new Date(timestamp.seconds * 1000);
+
+      const thumbsupUsers = (snapshot.get('thumbsupUsers') || []) as string[];
+
+      return {
+        uid: snapshot.id,
+        title: snapshot.get('title') || '',
+        memo: snapshot.get('memo') || '',
+        thumbsupUsers: thumbsupUsers,
+        thumbsupCount: snapshot.get('thumbsupCount'),
+        createdAt: createdAt,
+        userName: snapshot.get('userName') || '',
+        userID: snapshot.get('userID') || '',
+        userPhotoURL: snapshot.get('userPhotoURL') || '',
+      };
+    },
+    toFirestore(data: PrideContent): DocumentData {
+      return {
+        title: data.title,
+        memo: data.memo,
+        thumbsupCount: data.thumbsupCount,
+        thumbsupUsers: data.thumbsupUsers,
+        createdAt: data.createdAt ? data.createdAt : new Date(),
+        userID: data.userID,
+        userName: data.userName,
+        userPhotoURL: data.userPhotoURL,
+      };
+    },
+  };
+
+  async isExistPride(uid: string) {
+    const pride = await this.prideDB.doc(uid).get();
+    return pride.exists;
+  }
+
+  async getUsersPrideWithInOneMonth(uid: string) {
+    const today = new Date();
+    const oneMonthAgo =
+      today.getMonth() - 1 >= 0
+        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+        : new Date(today.getFullYear() - 1, 11, today.getDate());
+    // TODO:ここが年をまたぐ場合エラー回避
+    const prideCollection = await this.prideDB
+      .withConverter(this.prideConverter)
+      .where('userID', '==', uid)
+      .where('createdAt', '>=', oneMonthAgo)
+      .orderBy('createdAt', 'desc')
+      .get();
+    const prides = prideCollection.docs.map((doc) => doc.data());
+    //過去一か月のPrideを取得
+    return prides;
+  }
+
+  async getPridesWithinOneMonth() {
+    const today = new Date();
+    const oneMonthAgo =
+      today.getMonth() - 1 >= 0
+        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+        : new Date(today.getFullYear() - 1, 11, today.getDate());
+
+    // TODO:年をまたぐ場合にエラー回避
+    const prideCollection = await this.prideDB
+      .where('createdAt', '>=', oneMonthAgo)
+      .orderBy('createdAt', 'desc')
+      .withConverter(this.prideConverter)
+      .get();
+    const prides = prideCollection.docs.map((doc) => doc.data());
+    return prides;
+  }
+
+  async getPrideWithinOneMonthRanking() {
+    const today = new Date();
+
+    const oneMonthAgo =
+      today.getMonth() - 1 >= 0
+        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+        : new Date(today.getFullYear() - 1, 11, today.getDate());
+    // TODO:年をまたぐ場合にエラー回避
+    const prideCollection = await this.prideDB
+      .withConverter(this.prideConverter)
+      .where('createdAt', '>', oneMonthAgo)
+      .orderBy('createdAt', 'asc')
+      .orderBy('thumbsupCount', 'desc')
+      .limit(3)
+      .get();
+
+    const prides = prideCollection.docs.map((doc) => doc.data());
+
+    return prides;
+  }
+
+  async getPridePast() {
+    const today = new Date();
+    const oneMonthAgo =
+      today.getMonth() - 1 >= 0
+        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+        : new Date(today.getFullYear() - 1, 11, today.getDate());
+    const halfYearAgo =
+      today.getMonth() - 6 > 0
+        ? new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+        : new Date(today.getFullYear() - 1, 11 + today.getMonth() - 6, today.getDate());
+    // TODO:年をまたぐ場合にエラー回避
+    const prideCollection = await this.prideDB
+      .where('createdAt', '>=', halfYearAgo)
+      .where('createdAt', '<', oneMonthAgo)
+      .orderBy('createdAt', 'asc')
+      .withConverter(this.prideConverter)
+      .get();
+    const prides = prideCollection.docs.map((doc) => doc.data());
+    return prides;
+  }
+
+  async createPride(userID: string, userName: string, userPhotoURL: string, title: string, memo: string) {
+    this.prideDB.withConverter(this.prideConverter).add({
+      uid: '',
+      title: title,
+      memo: memo,
+      thumbsupUsers: [],
+      thumbsupCount: 0,
+      userID: userID,
+      userName: userName,
+      userPhotoURL: userPhotoURL,
+    });
+  }
+
+  async updatePride(prideID: string, title: string, memo: string) {
+    this.prideDB.doc(prideID).withConverter(this.prideConverter).update({
+      title: title,
+      memo: memo,
+    });
+  }
+
+  async deletePride(prideID: string) {
+    this.prideDB.doc(prideID).delete();
+  }
+
+  async ThumbUpPride(prideID: string, userPhoto: string) {
+    // 受け取った情報をもとに、いいねを更新する
+    const pride = await this.prideDB.doc(prideID).withConverter(this.prideConverter).get();
+    const data = pride.data();
+
+    const thumbsupUsers = data.thumbsupUsers;
+    const updateThumbsupUsers = thumbsupUsers.includes(userPhoto)
+      ? thumbsupUsers.filter((user) => user !== userPhoto)
+      : [...thumbsupUsers, userPhoto];
+    this.prideDB.doc(prideID).update({
+      thumbsupUsers: updateThumbsupUsers,
+      thumbsupCount: updateThumbsupUsers.length,
+    });
+  }
+}


### PR DESCRIPTION
Firestoreとの接続処理部分をService内から処理を切り出す。

## 変更点
- PrideService内にかかれていたFirestoreとの処理をstore/store-prideに処理を切り出し
- PrideUserService内にかかれていたFirestoreとの処理をstore/store-prideに処理を切り出し
- Firestore内のデータをいじる処理に関しては、sotreフォルダ内に記載するように変更

## 各ファイルの責務イメージ

 ファイル or ディレクトリ | 責務 
-- | --
Storeディレクトリ | FirestoreなどのDBからの入出力を記述 
各Serviceファイル | DBに書き込む前に完了しておきたい処理などを記述（今回はあんまりない）
各Controllerファイル | エラーハンドリングなどの処理をまとめる。具体的な処理はServiceに投げる



## 悩んでいる点

Prideの「いいね」処理に関して 
1. （PrideService）「いいね」対象のPrideの取得
2. （PrideService）「いいね」の登録状況によって取得したPrideに対して変更処理 
   - 「いいね」が押されていない場合は、配列に画像URLを追加する 
   - 「いいね」が押されている場合は、配列から画像URLを削除する
4. （Store）prideIDと変更後の「いいね」配列と「いいね」配列の長さをもとにPrideの更新